### PR TITLE
Alternative implementation to fix flip config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Driver for IT8951 E-Paper display
 
-This crate is mainly developed for the waveshare 7.8" epaper display using spi:
-https://www.waveshare.com/wiki/7.8inch_e-Paper_HAT
 The driver uses the embedded_hal traits as hardware abstraction layer.
 This driver can be used with the embedded graphics trait, currently only supporing Gray4 (16bit grayscale).
 
@@ -12,6 +10,14 @@ This driver can be used with the embedded graphics trait, currently only suppori
 - The crates uses the alloc feature to allocate memory on the heap:
     - Firmware and LUT version string read from the controller
     - Staging buffers to write pixel to the controller. The buffers are allocated as needed, but only one buffer at a time and with up to `Config::max_buffer_size`, which is 1kByte per default.
+
+## Supported devices
+
+It should support all waveshare devices using the IT8951 controller over SPI.
+These e-ink screens are known to be working
+
+* [7.8 inch, 1872×1404 pixels, 4-bit grayscale](https://www.waveshare.com/wiki/7.8inch_e-Paper_HAT)
+* [10.3 inch, 1872×1404 pixels, 4-bit grayscale](https://www.waveshare.com/wiki/10.3inch_e-Paper_HAT) **Important** This screen needs to be initialized with origin of `TopRight` to be working correctly
 
 ## Performance Considerations
 Always prefer the embedded_graphics `fill_solid` and `fill_contiguous` functions over `draw_iter`.
@@ -42,6 +48,7 @@ We are currently discussing approaches without alloc. If you have any opinion on
 
 ### Unreleased
 - Add optional defmt support
+- Add display origin support (fixes mirroring on certain devices)
 
 ### 0.4.2
 - add display rotation support

--- a/src/area_serializer.rs
+++ b/src/area_serializer.rs
@@ -1,4 +1,4 @@
-use crate::{serialization_helper::get_entires_per_row, AreaImgInfo};
+use crate::{serialization_helper::get_nibbles_per_row, AreaImgInfo};
 use alloc::vec::Vec;
 use embedded_graphics_core::{
     pixelcolor::{Gray4, GrayColor},
@@ -22,7 +22,7 @@ impl AreaSerializer {
             "Buffer size must be aligned to u16"
         );
         // calculate the buffer size
-        let entries_per_row = get_entires_per_row(area) as usize * 2; // convert length from u16 to u8
+        let entries_per_row = get_nibbles_per_row(area) as usize * 2; // convert length from u16 to u8
         let rows_per_step = (buffer_size / entries_per_row).min(area.size.height as usize);
         assert!(rows_per_step > 0, "Buffer size to small for one row");
         let buffer = vec![data_entry; entries_per_row * rows_per_step];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 #[macro_use]
 extern crate alloc;
+
 use alloc::string::String;
 use core::{borrow::Borrow, marker::PhantomData};
 
@@ -14,6 +15,7 @@ mod area_serializer;
 mod command;
 pub mod interface;
 pub mod memory_converter_settings;
+pub mod origin;
 mod pixel_serializer;
 mod register;
 mod serialization_helper;
@@ -158,33 +160,55 @@ pub struct Off;
 
 /// IT8951 e paper driver
 /// The controller supports multiple interfaces
-pub struct IT8951<IT8951Interface, State> {
+pub struct IT8951<IT8951Interface, TOrigin: Origin, State> {
     interface: IT8951Interface,
     dev_info: Option<DevInfo>,
     marker: core::marker::PhantomData<State>,
+    origin: core::marker::PhantomData<TOrigin>,
     config: Config,
 }
 
-impl<IT8951Interface: interface::IT8951Interface, TState> IT8951<IT8951Interface, TState> {
-    fn into_state<TNew>(self) -> IT8951<IT8951Interface, TNew> {
-        IT8951::<IT8951Interface, TNew> {
+impl<IT8951Interface: interface::IT8951Interface, TOrigin: Origin, TState>
+    IT8951<IT8951Interface, TOrigin, TState>
+{
+    fn into_state<TNew>(self) -> IT8951<IT8951Interface, TOrigin, TNew> {
+        IT8951::<IT8951Interface, TOrigin, TNew> {
             interface: self.interface,
             dev_info: self.dev_info,
             marker: PhantomData {},
+            origin: PhantomData {},
             config: self.config,
         }
     }
 }
 
-impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Off> {
+impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, OriginTopLeft, Off> {
     /// Creates a new controller driver object
     /// Call init afterwards to initalize the controller
-    pub fn new(mut interface: IT8951Interface, config: Config) -> Self {
+    pub fn new(
+        interface: IT8951Interface,
+        config: Config,
+    ) -> IT8951<IT8951Interface, OriginTopLeft, Off> {
+        Self::new_with_origin(interface, config, OriginTopLeft {})
+    }
+}
+
+impl<IT8951Interface: interface::IT8951Interface, TOrigin: Origin>
+    IT8951<IT8951Interface, TOrigin, Off>
+{
+    /// Creates a new controller driver object with a customized origin type
+    /// Call init afterwards to initalize the controller
+    pub fn new_with_origin(
+        mut interface: IT8951Interface,
+        config: Config,
+        _: TOrigin,
+    ) -> IT8951<IT8951Interface, TOrigin, Off> {
         interface.set_busy_timeout(config.timeout_interface);
         IT8951 {
             interface,
             dev_info: None,
             marker: PhantomData {},
+            origin: PhantomData {},
             config,
         }
     }
@@ -192,7 +216,7 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Off> {
     /// Initalize the driver and resets the display
     /// VCOM should be given on your display
     /// Since version 0.4.0, this function no longer resets the display
-    pub fn init(mut self, vcom: u16) -> Result<IT8951<IT8951Interface, Run>, Error> {
+    pub fn init(mut self, vcom: u16) -> Result<IT8951<IT8951Interface, TOrigin, Run>, Error> {
         self.interface.reset()?;
 
         let mut it8951 = self.into_state::<PowerDown>().sys_run()?;
@@ -230,13 +254,14 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Off> {
     pub fn attach(
         mut interface: IT8951Interface,
         config: Config,
-    ) -> Result<IT8951<IT8951Interface, Run>, Error> {
+    ) -> Result<IT8951<IT8951Interface, OriginTopLeft, Run>, Error> {
         interface.set_busy_timeout(config.timeout_interface);
 
-        let mut it8951 = IT8951 {
+        let mut it8951: IT8951<IT8951Interface, OriginTopLeft, Run> = IT8951 {
             interface,
             dev_info: None,
             marker: PhantomData {},
+            origin: PhantomData {},
             config,
         }
         .sys_run()?;
@@ -259,7 +284,9 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Off> {
     }
 }
 
-impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
+impl<IT8951Interface: interface::IT8951Interface, TOrigin: Origin>
+    IT8951<IT8951Interface, TOrigin, Run>
+{
     /// Get the Device information
     pub fn get_dev_info(&self) -> DevInfo {
         self.dev_info.clone().unwrap()
@@ -323,12 +350,13 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
         &mut self,
         target_mem_addr: u32,
         image_settings: TMemoryConverterSetting,
-        area_info: &AreaImgInfo,
+        area_info: &mut AreaImgInfo,
         data: &[u8],
     ) -> Result<(), Error> {
         // Note that area_info does not need to be rotated here, as controller hw will do the rotation
         self.set_target_memory_addr(target_mem_addr)?;
 
+        TOrigin::transform(area_info, self.dev_info.as_ref().unwrap());
         self.interface.write_command_with_args(
             command::IT8951_TCON_LD_IMG_AREA,
             &[
@@ -525,7 +553,7 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
 
     /// Activate sleep power mode
     /// All clocks, pll, osc and the panel are off, but the ram is refreshed
-    pub fn sleep(mut self) -> Result<IT8951<IT8951Interface, PowerDown>, Error> {
+    pub fn sleep(mut self) -> Result<IT8951<IT8951Interface, TOrigin, PowerDown>, Error> {
         self.interface.write_command(command::IT8951_TCON_SLEEP)?;
 
         #[cfg(feature = "defmt")]
@@ -536,7 +564,7 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
 
     /// Activate standby power mode
     /// Clocks are gated off, but pll, osc, panel power and ram is active
-    pub fn standby(mut self) -> Result<IT8951<IT8951Interface, PowerDown>, Error> {
+    pub fn standby(mut self) -> Result<IT8951<IT8951Interface, TOrigin, PowerDown>, Error> {
         self.interface.write_command(command::IT8951_TCON_STANDBY)?;
 
         #[cfg(feature = "defmt")]
@@ -644,10 +672,12 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
     }
 }
 
-impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, PowerDown> {
+impl<IT8951Interface: interface::IT8951Interface, TOrigin: Origin>
+    IT8951<IT8951Interface, TOrigin, PowerDown>
+{
     /// Activate active power mode
     /// This is the normal operation power mode
-    pub fn sys_run(mut self) -> Result<IT8951<IT8951Interface, Run>, Error> {
+    pub fn sys_run(mut self) -> Result<IT8951<IT8951Interface, TOrigin, Run>, Error> {
         self.interface.write_command(command::IT8951_TCON_SYS_RUN)?;
 
         #[cfg(feature = "defmt")]
@@ -661,7 +691,11 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, PowerD
 
 use embedded_graphics_core::{pixelcolor::Gray4, prelude::*, primitives::Rectangle};
 
-impl<IT8951Interface: interface::IT8951Interface> DrawTarget for IT8951<IT8951Interface, Run> {
+use crate::origin::{Origin, OriginTopLeft};
+
+impl<IT8951Interface: interface::IT8951Interface, TOrigin: Origin> DrawTarget
+    for IT8951<IT8951Interface, TOrigin, Run>
+{
     type Color = Gray4;
 
     type Error = Error;
@@ -697,14 +731,14 @@ impl<IT8951Interface: interface::IT8951Interface> DrawTarget for IT8951<IT8951In
             .map(|d| d.memory_address)
             .expect("Dev info not initialized");
 
-        for (area_img_info, buffer) in area_iter {
+        for (mut area_img_info, buffer) in area_iter {
             self.load_image_area(
                 memory_address,
                 MemoryConverterSetting {
                     rotation: (&self.config.rotation).into(),
                     ..Default::default()
                 },
-                &area_img_info,
+                &mut area_img_info,
                 buffer,
             )?;
         }
@@ -727,16 +761,21 @@ impl<IT8951Interface: interface::IT8951Interface> DrawTarget for IT8951<IT8951In
             .map(|d| d.memory_address)
             .expect("Dev info not initialized");
 
-        let pixel = PixelSerializer::new(area.intersection(&bb), iter, self.config.max_buffer_size);
+        let pixel = PixelSerializer::<_, TOrigin>::new(
+            area.intersection(&bb),
+            iter,
+            self.config.max_buffer_size,
+        );
 
-        for (area_img_info, buffer) in pixel {
+        for (mut area_img_info, buffer) in pixel {
             self.load_image_area(
                 memory_address,
                 MemoryConverterSetting {
+                    endianness: memory_converter_settings::MemoryConverterEndianness::LittleEndian,
                     rotation: (&self.config.rotation).into(),
                     ..Default::default()
                 },
-                &area_img_info,
+                &mut area_img_info,
                 &buffer,
             )?;
         }
@@ -770,7 +809,7 @@ impl<IT8951Interface: interface::IT8951Interface> DrawTarget for IT8951<IT8951In
                         rotation: (&self.config.rotation).into(),
                         ..Default::default()
                     },
-                    &AreaImgInfo {
+                    &mut AreaImgInfo {
                         area_x: coord.x as u16,
                         area_y: coord.y as u16,
                         area_w: 1,
@@ -788,8 +827,8 @@ impl<IT8951Interface: interface::IT8951Interface> DrawTarget for IT8951<IT8951In
     }
 }
 
-impl<IT8951Interface: interface::IT8951Interface> OriginDimensions
-    for IT8951<IT8951Interface, Run>
+impl<IT8951Interface: interface::IT8951Interface, TOrigin: Origin> OriginDimensions
+    for IT8951<IT8951Interface, TOrigin, Run>
 {
     fn size(&self) -> Size {
         let dev_info = self.dev_info.as_ref().unwrap();

--- a/src/origin.rs
+++ b/src/origin.rs
@@ -1,0 +1,91 @@
+//! Trait to manage origin of the coordinate system
+
+/// Origin for TopLeft corner
+pub struct OriginTopLeft;
+/// Origin for TopRight corner
+pub struct OriginTopRight;
+
+mod private {
+    use core::ops::BitXor;
+    use embedded_graphics_core::{prelude::Point, primitives::Rectangle};
+
+    use crate::{AreaImgInfo, DevInfo};
+
+    pub trait Sealed {
+        /// Transforms the AreaImgInfo
+        fn transform(area_img_info: &mut AreaImgInfo, dev_info: &DevInfo);
+
+        /// Determines the right position in a area image buffer for a given pixel
+        fn bit_and_byte_pos(
+            area: &Rectangle,
+            point: Point,
+            nibbles_per_row: usize,
+            row: usize,
+            start_row: usize,
+        ) -> (usize, i32);
+    }
+
+    impl Sealed for super::OriginTopLeft {
+        #[inline(always)]
+        fn transform(_: &mut AreaImgInfo, _: &DevInfo) {
+            // NoOp
+        }
+
+        #[inline(always)]
+        fn bit_and_byte_pos(
+            area: &Rectangle,
+            point: Point,
+            nibbles_per_row: usize,
+            row: usize,
+            start_row: usize,
+        ) -> (usize, i32) {
+            let u16_pos = ((point.x - (area.top_left.x / 4 * 4)) / 2) as usize
+                + nibbles_per_row * (row - start_row);
+
+            // swap last pixel to map little endian behavior
+            let byte_pos = u16_pos.bitxor(0x00001);
+
+            // little endian layout
+            // [P3, P2 | P1, P0]
+            let bit_pos = (point.x % 2) * 4;
+
+            (byte_pos, bit_pos)
+        }
+    }
+
+    impl Sealed for super::OriginTopRight {
+        #[inline(always)]
+        fn transform(area_img_info: &mut AreaImgInfo, dev_info: &DevInfo) {
+            area_img_info.area_x =
+                dev_info.panel_width - area_img_info.area_x - area_img_info.area_w;
+        }
+
+        #[inline(always)]
+        fn bit_and_byte_pos(
+            area: &Rectangle,
+            point: Point,
+            nibbles_per_row: usize,
+            row: usize,
+            start_row: usize,
+        ) -> (usize, i32) {
+            let u16_pos =
+                nibbles_per_row - 1 - ((point.x - (area.top_left.x / 4 * 4)) / 2) as usize
+                    + nibbles_per_row * (row - start_row);
+
+            // swap last pixel to map little endian behavior
+            let byte_pos = u16_pos.bitxor(0x00001);
+
+            // little endian layout
+            // [P3, P2 | P1, P0]
+            let bit_pos = ((point.x + 1) % 2) * 4;
+
+            (byte_pos, bit_pos)
+        }
+    }
+}
+
+/// Origin trait to transforrm AreaImgInfo before sending to controller
+pub trait Origin: private::Sealed {}
+
+impl Origin for OriginTopLeft {}
+impl Origin for OriginTopRight {}

--- a/src/pixel_serializer.rs
+++ b/src/pixel_serializer.rs
@@ -1,6 +1,6 @@
-use core::{borrow::Borrow, ops::BitXor};
+use core::{borrow::Borrow, marker::PhantomData};
 
-use crate::{serialization_helper::get_entires_per_row, AreaImgInfo};
+use crate::{serialization_helper::get_nibbles_per_row, AreaImgInfo, Origin};
 use alloc::vec::Vec;
 use embedded_graphics_core::{
     pixelcolor::Gray4,
@@ -10,14 +10,15 @@ use embedded_graphics_core::{
 };
 
 /// Converts a list of Pixels (pos, color) into frame buffer segements with area information.
-pub struct PixelSerializer<I: Iterator<Item = Pixel<Gray4>>> {
+pub struct PixelSerializer<I: Iterator<Item = Pixel<Gray4>>, TOrigin: Origin> {
     area: Rectangle,
     pixels: I,
     row: usize,
     max_entries: usize,
+    origin: PhantomData<TOrigin>,
 }
 
-impl<I: Iterator<Item = Pixel<Gray4>>> PixelSerializer<I> {
+impl<I: Iterator<Item = Pixel<Gray4>>, TOrigin: Origin> PixelSerializer<I, TOrigin> {
     pub fn new(area: Rectangle, pixels: I, size: usize) -> Self {
         PixelSerializer {
             area,
@@ -25,11 +26,12 @@ impl<I: Iterator<Item = Pixel<Gray4>>> PixelSerializer<I> {
             row: 0,
             // 1kByte
             max_entries: size,
+            origin: PhantomData {},
         }
     }
 }
 
-impl<I: Iterator<Item = Pixel<Gray4>>> Iterator for PixelSerializer<I> {
+impl<I: Iterator<Item = Pixel<Gray4>>, TOrigin: Origin> Iterator for PixelSerializer<I, TOrigin> {
     type Item = (AreaImgInfo, Vec<u8>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -40,23 +42,21 @@ impl<I: Iterator<Item = Pixel<Gray4>>> Iterator for PixelSerializer<I> {
         let start_row = self.row;
 
         // prepare buffer with enough capacity
-        let entries_per_row = get_entires_per_row(self.area) as usize * 2; // convert length to bytes
-        let max_rows = (self.max_entries / entries_per_row).min(self.area.size.height as usize);
-        assert!(max_rows > 0, "Buffer size to small for one row");
-        let mut bytes = vec![0x00; entries_per_row * max_rows];
+        let nibbles_per_row = get_nibbles_per_row(self.area) as usize * 2; // convert length to bytes
+        let max_rows_per_iter =
+            (self.max_entries / nibbles_per_row).min(self.area.size.height as usize);
+        assert!(max_rows_per_iter > 0, "Buffer size to small for one row");
+        // Make sure to not overallocate at the end of the area
+        let number_of_rows_for_iter =
+            max_rows_per_iter.min(self.area.size.height as usize - self.row);
+
+        let mut bytes = vec![0x00; nibbles_per_row * number_of_rows_for_iter];
 
         // add all pixels to buffer
         for Pixel(point, color) in self.pixels.by_ref() {
             // calculate the which u16 (pair of two bytes) the pixel is in
-            let u16_pos = ((point.x - (self.area.top_left.x / 4 * 4)) / 2) as usize
-                + entries_per_row * (self.row - start_row);
-
-            // swap last pixel to map little endian behavior
-            let byte_pos = u16_pos.bitxor(0x00001);
-
-            // little endian layout
-            // [P3, P2 | P1, P0]
-            let bit_pos = (point.x % 2) * 4;
+            let (byte_pos, bit_pos) =
+                TOrigin::bit_and_byte_pos(&self.area, point, nibbles_per_row, self.row, start_row);
 
             bytes[byte_pos] |= (color.luma()) << bit_pos;
 
@@ -65,7 +65,7 @@ impl<I: Iterator<Item = Pixel<Gray4>>> Iterator for PixelSerializer<I> {
                 self.row += 1;
             }
             // abort if all rows are written to buffer
-            if self.row >= max_rows + start_row {
+            if self.row >= max_rows_per_iter + start_row {
                 break;
             }
         }
@@ -100,6 +100,8 @@ pub fn convert_color_to_pixel_iterator<In: Iterator<Item = Gray4>, TRect: Borrow
 
 #[cfg(test)]
 mod tests {
+    use crate::origin::{OriginTopLeft, OriginTopRight};
+
     use super::*;
 
     const BOUNDING_BOX_DEFAULT: Rectangle = Rectangle {
@@ -120,7 +122,7 @@ mod tests {
                 height: 1,
             },
         };
-        let mut s = PixelSerializer::new(
+        let mut s = PixelSerializer::<_, OriginTopLeft>::new(
             area.intersection(&BOUNDING_BOX_DEFAULT),
             convert_color_to_pixel_iterator(
                 area,
@@ -154,7 +156,7 @@ mod tests {
                 height: 1,
             },
         };
-        let mut s = PixelSerializer::new(
+        let mut s = PixelSerializer::<_, OriginTopLeft>::new(
             area.intersection(&BOUNDING_BOX_DEFAULT),
             convert_color_to_pixel_iterator(
                 area,
@@ -187,7 +189,7 @@ mod tests {
                 height: 1,
             },
         };
-        let mut s = PixelSerializer::new(
+        let mut s = PixelSerializer::<_, OriginTopLeft>::new(
             area.intersection(&BOUNDING_BOX_DEFAULT),
             convert_color_to_pixel_iterator(
                 area,
@@ -220,7 +222,7 @@ mod tests {
                 height: 1,
             },
         };
-        let mut s = PixelSerializer::new(
+        let mut s = PixelSerializer::<_, OriginTopLeft>::new(
             area.intersection(&BOUNDING_BOX_DEFAULT),
             convert_color_to_pixel_iterator(
                 area,
@@ -254,7 +256,7 @@ mod tests {
                 height: 1,
             },
         };
-        let mut s = PixelSerializer::new(
+        let mut s = PixelSerializer::<_, OriginTopLeft>::new(
             area.intersection(&BOUNDING_BOX_DEFAULT),
             convert_color_to_pixel_iterator(
                 area,
@@ -294,7 +296,7 @@ mod tests {
                 height: 1,
             },
         };
-        let mut s = PixelSerializer::new(
+        let mut s = PixelSerializer::<_, OriginTopLeft>::new(
             area.intersection(&BOUNDING_BOX_DEFAULT),
             convert_color_to_pixel_iterator(
                 area,
@@ -328,7 +330,7 @@ mod tests {
                 height: 2,
             },
         };
-        let mut s = PixelSerializer::new(
+        let mut s = PixelSerializer::<_, OriginTopLeft>::new(
             area.intersection(&BOUNDING_BOX_DEFAULT),
             convert_color_to_pixel_iterator(
                 area,
@@ -384,7 +386,7 @@ mod tests {
                 height: 2,
             },
         };
-        let mut s = PixelSerializer::new(
+        let mut s = PixelSerializer::<_, OriginTopLeft>::new(
             area.intersection(&BOUNDING_BOX_DEFAULT),
             convert_color_to_pixel_iterator(
                 area,
@@ -438,7 +440,7 @@ mod tests {
                 height: 2,
             },
         };
-        let mut s = PixelSerializer::new(
+        let mut s = PixelSerializer::<_, OriginTopLeft>::new(
             area.intersection(&BOUNDING_BOX_DEFAULT),
             convert_color_to_pixel_iterator(
                 area,
@@ -482,7 +484,7 @@ mod tests {
                 height: 2,
             },
         };
-        let mut s = PixelSerializer::new(
+        let mut s = PixelSerializer::<_, OriginTopLeft>::new(
             area.intersection(&BOUNDING_BOX_DEFAULT),
             convert_color_to_pixel_iterator(
                 area,
@@ -524,7 +526,7 @@ mod tests {
                 height: 2,
             },
         };
-        let mut s = PixelSerializer::new(
+        let mut s = PixelSerializer::<_, OriginTopLeft>::new(
             area.intersection(&BOUNDING_BOX_DEFAULT),
             convert_color_to_pixel_iterator(
                 area,
@@ -551,6 +553,465 @@ mod tests {
                     area_h: 1
                 },
                 vec![0x00, 0x32]
+            ))
+        );
+        assert_eq!(s.next(), None);
+    }
+
+    #[test]
+    // single pixel in bounding box at pos 0
+    fn test_pixel_0_origin_top_right() {
+        let area = Rectangle {
+            top_left: Point { x: 0, y: 0 },
+            size: Size {
+                width: 1,
+                height: 1,
+            },
+        };
+        let mut s = PixelSerializer::<_, OriginTopRight>::new(
+            area.intersection(&BOUNDING_BOX_DEFAULT),
+            convert_color_to_pixel_iterator(
+                area,
+                BOUNDING_BOX_DEFAULT,
+                vec![Gray4::new(0xF)].into_iter(),
+            ),
+            1024,
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 0,
+                    area_y: 0,
+                    area_w: 1,
+                    area_h: 1
+                },
+                // vec![0x00, 0x0F]
+                vec![0xF0, 0x00]
+            ))
+        );
+        assert_eq!(s.next(), None);
+    }
+
+    #[test]
+    // single pixel in bounding box at pos 1
+    fn test_pixel_1_origin_top_right() {
+        let area = Rectangle {
+            top_left: Point { x: 1, y: 1 },
+            size: Size {
+                width: 1,
+                height: 1,
+            },
+        };
+        let mut s = PixelSerializer::<_, OriginTopRight>::new(
+            area.intersection(&BOUNDING_BOX_DEFAULT),
+            convert_color_to_pixel_iterator(
+                area,
+                BOUNDING_BOX_DEFAULT,
+                vec![Gray4::new(0x1)].into_iter(),
+            ),
+            1024,
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 1,
+                    area_y: 1,
+                    area_w: 1,
+                    area_h: 1
+                },
+                //vec![0x00, 0x10]
+                vec![0x01, 0x00]
+            ))
+        );
+        assert_eq!(s.next(), None);
+    }
+    #[test]
+    // single pixel in bounding box at pos 2
+    fn test_pixel_2_origin_top_right() {
+        let area = Rectangle {
+            top_left: Point { x: 2, y: 1 },
+            size: Size {
+                width: 1,
+                height: 1,
+            },
+        };
+        let mut s = PixelSerializer::<_, OriginTopRight>::new(
+            area.intersection(&BOUNDING_BOX_DEFAULT),
+            convert_color_to_pixel_iterator(
+                area,
+                BOUNDING_BOX_DEFAULT,
+                vec![Gray4::new(0x4)].into_iter(),
+            ),
+            1024,
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 2,
+                    area_y: 1,
+                    area_w: 1,
+                    area_h: 1
+                },
+                // vec![0x04, 0x00]
+                vec![0x00, 0x40]
+            ))
+        );
+        assert_eq!(s.next(), None);
+    }
+    #[test]
+    // single pixel in bounding box at pos 3
+    fn test_pixel_3_origin_top_right() {
+        let area = Rectangle {
+            top_left: Point { x: 3, y: 1 },
+            size: Size {
+                width: 1,
+                height: 1,
+            },
+        };
+        let mut s = PixelSerializer::<_, OriginTopRight>::new(
+            area.intersection(&BOUNDING_BOX_DEFAULT),
+            convert_color_to_pixel_iterator(
+                area,
+                BOUNDING_BOX_DEFAULT,
+                vec![Gray4::new(0xC)].into_iter(),
+            ),
+            1024,
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 3,
+                    area_y: 1,
+                    area_w: 1,
+                    area_h: 1
+                },
+                // vec![0xC0, 0x00]
+                vec![0x00, 0x0C]
+            ))
+        );
+        assert_eq!(s.next(), None);
+    }
+
+    #[test]
+    // 4 pixels in a row, aligned
+    fn test_pixel_single_row_packed_origin_top_right() {
+        let area = Rectangle {
+            top_left: Point { x: 4, y: 1 },
+            size: Size {
+                width: 4,
+                height: 1,
+            },
+        };
+        let mut s = PixelSerializer::<_, OriginTopRight>::new(
+            area.intersection(&BOUNDING_BOX_DEFAULT),
+            convert_color_to_pixel_iterator(
+                area,
+                BOUNDING_BOX_DEFAULT,
+                vec![
+                    Gray4::new(0xA),
+                    Gray4::new(0xB),
+                    Gray4::new(0xC),
+                    Gray4::new(0xD),
+                ]
+                .into_iter(),
+            ),
+            1024,
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 4,
+                    area_y: 1,
+                    area_w: 4,
+                    area_h: 1
+                },
+                // vec![0xDC, 0xBA]
+                vec![0xAB, 0xCD]
+            ))
+        );
+        assert_eq!(s.next(), None);
+    }
+
+    #[test]
+    // 3 pixels in a row, not aligned
+    fn test_pixel_single_row_origin_top_right() {
+        let area = Rectangle {
+            top_left: Point { x: 3, y: 1 },
+            size: Size {
+                width: 3,
+                height: 1,
+            },
+        };
+        let mut s = PixelSerializer::<_, OriginTopRight>::new(
+            area.intersection(&BOUNDING_BOX_DEFAULT),
+            convert_color_to_pixel_iterator(
+                area,
+                BOUNDING_BOX_DEFAULT,
+                vec![Gray4::new(0xC), Gray4::new(0xD), Gray4::new(0xE)].into_iter(),
+            ),
+            1024,
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 3,
+                    area_y: 1,
+                    area_w: 3,
+                    area_h: 1
+                },
+                // vec![0xC0, 0x00, 0x00, 0xED]
+                vec![0xDE, 0x00, 0x00, 0x0C]
+            ))
+        );
+        assert_eq!(s.next(), None);
+    }
+
+    #[test]
+    // two rows of pixels, aligned
+    fn test_pixel_rows_packed_origin_top_right() {
+        let area = Rectangle {
+            top_left: Point { x: 4, y: 1 },
+            size: Size {
+                width: 4,
+                height: 2,
+            },
+        };
+        let mut s = PixelSerializer::<_, OriginTopRight>::new(
+            area.intersection(&BOUNDING_BOX_DEFAULT),
+            convert_color_to_pixel_iterator(
+                area,
+                BOUNDING_BOX_DEFAULT,
+                vec![
+                    Gray4::new(0xA),
+                    Gray4::new(0xB),
+                    Gray4::new(0xC),
+                    Gray4::new(0xD),
+                    Gray4::new(0x1),
+                    Gray4::new(0x2),
+                    Gray4::new(0x3),
+                    Gray4::new(0x4),
+                ]
+                .into_iter(),
+            ),
+            2,
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 4,
+                    area_y: 1,
+                    area_w: 4,
+                    area_h: 1
+                },
+                // vec![0xDC, 0xBA]
+                vec![0xAB, 0xCD]
+            ))
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 4,
+                    area_y: 2,
+                    area_w: 4,
+                    area_h: 1
+                },
+                // vec![0x43, 0x21]
+                vec![0x12, 0x34]
+            ))
+        );
+        assert_eq!(s.next(), None);
+    }
+
+    #[test]
+    // two rows of pixels, not aligned
+    fn test_pixel_rows_origin_top_right() {
+        let area = Rectangle {
+            top_left: Point { x: 3, y: 1 },
+            size: Size {
+                width: 3,
+                height: 2,
+            },
+        };
+        let mut s = PixelSerializer::<_, OriginTopRight>::new(
+            area.intersection(&BOUNDING_BOX_DEFAULT),
+            convert_color_to_pixel_iterator(
+                area,
+                BOUNDING_BOX_DEFAULT,
+                vec![
+                    Gray4::new(0xC),
+                    Gray4::new(0xD),
+                    Gray4::new(0xE),
+                    Gray4::new(0x1),
+                    Gray4::new(0x2),
+                    Gray4::new(0x3),
+                ]
+                .into_iter(),
+            ),
+            4,
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 3,
+                    area_y: 1,
+                    area_w: 3,
+                    area_h: 1
+                },
+                // vec![0xC0, 0x00, 0x00, 0xED]
+                vec![0xDE, 0x00, 0x00, 0x0C]
+            ))
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 3,
+                    area_y: 2,
+                    area_w: 3,
+                    area_h: 1
+                },
+                // vec![0x10, 0x00, 0x00, 0x32]
+                vec![0x23, 0x00, 0x00, 0x01]
+            ))
+        );
+        assert_eq!(s.next(), None);
+    }
+
+    #[test]
+    // two rows of pixels, aligned
+    fn test_pixel_rows_packed_multirow_origin_top_right() {
+        let area = Rectangle {
+            top_left: Point { x: 4, y: 1 },
+            size: Size {
+                width: 4,
+                height: 2,
+            },
+        };
+        let mut s = PixelSerializer::<_, OriginTopRight>::new(
+            area.intersection(&BOUNDING_BOX_DEFAULT),
+            convert_color_to_pixel_iterator(
+                area,
+                BOUNDING_BOX_DEFAULT,
+                vec![
+                    Gray4::new(0xA),
+                    Gray4::new(0xB),
+                    Gray4::new(0xC),
+                    Gray4::new(0xD),
+                    Gray4::new(0x1),
+                    Gray4::new(0x2),
+                    Gray4::new(0x3),
+                    Gray4::new(0x4),
+                ]
+                .into_iter(),
+            ),
+            1024,
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 4,
+                    area_y: 1,
+                    area_w: 4,
+                    area_h: 2
+                },
+                // vec![0xDC, 0xBA, 0x43, 0x21]
+                vec![0xAB, 0xCD, 0x12, 0x34]
+            ))
+        );
+        assert_eq!(s.next(), None);
+    }
+
+    #[test]
+    // two rows of pixels, not aligned
+    fn test_pixel_rows_multirow_origin_top_right() {
+        let area = Rectangle {
+            top_left: Point { x: 3, y: 1 },
+            size: Size {
+                width: 3,
+                height: 2,
+            },
+        };
+        let mut s = PixelSerializer::<_, OriginTopRight>::new(
+            area.intersection(&BOUNDING_BOX_DEFAULT),
+            convert_color_to_pixel_iterator(
+                area,
+                BOUNDING_BOX_DEFAULT,
+                vec![
+                    Gray4::new(0xC),
+                    Gray4::new(0xD),
+                    Gray4::new(0xE),
+                    Gray4::new(0x1),
+                    Gray4::new(0x2),
+                    Gray4::new(0x3),
+                ]
+                .into_iter(),
+            ),
+            1024,
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 3,
+                    area_y: 1,
+                    area_w: 3,
+                    area_h: 2
+                },
+                //vec![0xC0, 0x00, 0x00, 0xED, 0x10, 0x00, 0x00, 0x32]
+                vec![0xDE, 0x00, 0x00, 0x0C, 0x23, 0x00, 0x00, 0x01]
+            ))
+        );
+        assert_eq!(s.next(), None);
+    }
+
+    #[test]
+    // two rows of pixels, not aligned, top left pixels are out of drawable area
+    fn test_pixel_non_drawable_top_left_origin_top_right() {
+        let area = Rectangle {
+            top_left: Point { x: -1, y: -1 },
+            size: Size {
+                width: 3,
+                height: 2,
+            },
+        };
+        let mut s = PixelSerializer::<_, OriginTopRight>::new(
+            area.intersection(&BOUNDING_BOX_DEFAULT),
+            convert_color_to_pixel_iterator(
+                area,
+                BOUNDING_BOX_DEFAULT,
+                vec![
+                    Gray4::new(0xC),
+                    Gray4::new(0xD),
+                    Gray4::new(0xE),
+                    Gray4::new(0x1),
+                    Gray4::new(0x2),
+                    Gray4::new(0x3),
+                ]
+                .into_iter(),
+            ),
+            1024,
+        );
+        assert_eq!(
+            s.next(),
+            Some((
+                AreaImgInfo {
+                    area_x: 0,
+                    area_y: 0,
+                    area_w: 2,
+                    area_h: 1
+                },
+                // vec![0x00, 0x32]
+                vec![0x23, 0x00]
             ))
         );
         assert_eq!(s.next(), None);

--- a/src/serialization_helper.rs
+++ b/src/serialization_helper.rs
@@ -2,7 +2,7 @@ use embedded_graphics_core::primitives::Rectangle;
 
 /// Calculates how many u16 values are necessary per line on the display.
 /// This includes the correct alignment
-pub fn get_entires_per_row(area: Rectangle) -> u32 {
+pub fn get_nibbles_per_row(area: Rectangle) -> u32 {
     const PIXEL_PER_WORD: u32 = 4;
 
     let alignment_pixels = area.top_left.x as u32 % 4;
@@ -16,19 +16,19 @@ mod tests {
 
     use super::*;
 
-    macro_rules! get_entires_per_row_tests {
+    macro_rules! get_nibbles_per_row_tests {
         ($($name:ident: $value:expr,)*) => {
         $(
             #[test]
             fn $name() {
                 let (offset, width, expected) = $value;
-                assert_eq!(expected, get_entires_per_row(Rectangle::new(Point::new(offset, 0), Size::new(width, 1))));
+                assert_eq!(expected, get_nibbles_per_row(Rectangle::new(Point::new(offset, 0), Size::new(width, 1))));
             }
         )*
         }
     }
 
-    get_entires_per_row_tests! {
+    get_nibbles_per_row_tests! {
         aligned_0: (0, 0, 0),
         aligned_1: (0, 1, 1),
         aligned_2: (0, 2, 1),


### PR DESCRIPTION
My hope is that by using a (compile time) known type and inlining the transform methods it would not incur a performance penalty for no transformation and also minimal one for cases where transform happens (ie only the subtractions).

Currently untested, but it seems to compile so I assume it works...