### PR TITLE
Fix #21 do not need an allocatable buffer to read data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This driver can be used with the embedded graphics trait, currently only suppori
 - The crates uses the alloc feature to allocate memory on the heap:
     - Firmware and LUT version string read from the controller
     - Staging buffers to write pixel to the controller. The buffers are allocated as needed, but only one buffer at a time and with up to `Config::max_buffer_size`, which is 1kByte per default.
-    - When reading controller memory a staging buffer with the size of of the requested data is created.
 
 ## Performance Considerations
 Always prefer the embedded_graphics `fill_solid` and `fill_contiguous` functions over `draw_iter`.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -55,7 +55,8 @@ pub trait IT8951Interface {
     fn read_data(&mut self) -> Result<u16, Error>;
 
     /// read multiple 16bit values
-    fn read_multi_data(&mut self, buf: &mut [u16]) -> Result<(), Error>;
+    /// Data must be aligned to u16!
+    fn read_multi_data(&mut self, buf: &mut [u8]) -> Result<(), Error>;
 
     /// reset the controller
     fn reset(&mut self) -> Result<(), Error>;
@@ -221,30 +222,27 @@ where
         Ok(u16::from_be_bytes([buf[4], buf[5]]))
     }
 
-    fn read_multi_data(&mut self, buf: &mut [u16]) -> Result<(), Error> {
+    fn read_multi_data(&mut self, buf: &mut [u8]) -> Result<(), Error> {
         self.wait_while_busy()?;
-        // create a u8 buffer
-        let mut read_buf = vec![0u8; buf.len()*2 /* nbr of data bytes */ + 2 /*dummby bytes */ + 2 /* read preamble */];
+
+        if !buf.len().is_multiple_of(2) {
+            #[cfg(feature = "defmt")]
+            defmt::warn!("Buffer alignment error");
+
+            return Err(Error::BufferAlignment);
+        };
 
         // 0x1000 prefix for read data
-        read_buf[0] = 0x10;
-        read_buf[1] = 0x00;
-
-        if self.spi.transfer_in_place(&mut read_buf).is_err() {
+        let cmd = [0x10_u8, 0x00, 0x00, 0x00];
+        if self
+            .spi
+            .transaction(&mut [Operation::Write(&cmd), Operation::TransferInPlace(buf)])
+            .is_err()
+        {
             #[cfg(feature = "defmt")]
-            defmt::warn!("SPI Error while writing");
+            defmt::warn!("SPI Error while reading");
 
             return Err(Error::SpiError);
-        }
-
-        // we skip the first 2 bytes -> shifted out while transfer the prefix
-        // the next two bytes are only dummies and are skipped to
-        const OFFSET: usize = 4;
-        for index in 0..buf.len() {
-            buf[index] = u16::from_be_bytes([
-                read_buf[OFFSET + index * 2],
-                read_buf[OFFSET + index * 2 + 1],
-            ]);
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,12 +389,18 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
             memory_address
         );
 
+        Self::convert_endianness(data);
+
         Ok(())
     }
 
     /// Writes a buffer of u16 values to the given memory address in the controller ram
     /// Buffer needs to be aligned to u16!
-    pub fn memory_burst_write(&mut self, memory_address: u32, data: &[u8]) -> Result<(), Error> {
+    pub fn memory_burst_write(
+        &mut self,
+        memory_address: u32,
+        data: &mut [u8],
+    ) -> Result<(), Error> {
         let args = [
             memory_address as u16,
             (memory_address >> 16) as u16,
@@ -403,6 +409,8 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
         ];
         self.interface
             .write_command_with_args(command::IT8951_TCON_MEM_BST_WR, &args)?;
+
+        Self::convert_endianness(data);
 
         self.interface.write_multi_data(data)?;
 
@@ -547,9 +555,7 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
         let mut buf = [0x0000; 40];
         self.interface.read_multi_data(&mut buf)?;
 
-        for i in (0..buf.len() - 1).step_by(2) {
-            buf.swap(i, i + 1)
-        }
+        Self::convert_endianness(&mut buf);
 
         Ok(DevInfo {
             panel_width: u16::from_be_bytes([buf[1], buf[0]]),
@@ -558,6 +564,16 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
             firmware_version: Self::buf_to_str(&buf[8..24]),
             lut_version: Self::buf_to_str(&buf[25..40]),
         })
+    }
+
+    fn convert_endianness(buffer: &mut [u8]) {
+        if !buffer.len().is_multiple_of(2) {
+            panic!("Buffer needs to be align on u16");
+        }
+
+        for i in (0..buffer.len() - 1).step_by(2) {
+            buffer.swap(i, i + 1)
+        }
     }
 
     fn buf_to_str(buffer: &[u8]) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,8 @@
 
 #[macro_use]
 extern crate alloc;
-use core::{borrow::Borrow, marker::PhantomData};
-
 use alloc::string::String;
+use core::{borrow::Borrow, marker::PhantomData};
 
 mod area_serializer;
 mod command;
@@ -213,11 +212,12 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Off> {
 
         #[cfg(feature = "defmt")]
         defmt::info!(
-            "Initialized screen Resolution {}x{}, LUT {=str}, FWV {=str}",
+            "Initialized screen Resolution {}x{}, LUT {=str}, FWV {=str} MA = {:x}",
             dev_info.panel_width,
             dev_info.panel_height,
             dev_info.lut_version,
             dev_info.firmware_version,
+            dev_info.memory_address,
         );
 
         it8951.dev_info = Some(dev_info);
@@ -364,11 +364,8 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
     // buffer functions -------------------------------------------------------------------------------------------------
 
     /// Reads the given memory address from the controller ram into data
-    pub fn memory_burst_read(
-        &mut self,
-        memory_address: u32,
-        data: &mut [u16],
-    ) -> Result<(), Error> {
+    /// Buffer needs to be aligned to u16!
+    pub fn memory_burst_read(&mut self, memory_address: u32, data: &mut [u8]) -> Result<(), Error> {
         let args = [
             memory_address as u16,
             (memory_address >> 16) as u16,
@@ -388,7 +385,7 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
         #[cfg(feature = "defmt")]
         defmt::trace!(
             "Read {} bytes of data from {:x}",
-            data.len() * 2,
+            data.len(),
             memory_address
         );
 
@@ -547,30 +544,29 @@ impl<IT8951Interface: interface::IT8951Interface> IT8951<IT8951Interface, Run> {
         self.interface.wait_while_busy()?;
 
         // 40 bytes payload
-        let mut buf = [0x0000; 20];
+        let mut buf = [0x0000; 40];
         self.interface.read_multi_data(&mut buf)?;
 
+        for i in (0..buf.len() - 1).step_by(2) {
+            buf.swap(i, i + 1)
+        }
+
         Ok(DevInfo {
-            panel_width: buf[0],
-            panel_height: buf[1],
-            memory_address: ((buf[3] as u32) << 16) | (buf[2] as u32),
-            firmware_version: self.buf_to_string(&buf[4..12]),
-            lut_version: self.buf_to_string(&buf[12..20]),
+            panel_width: u16::from_be_bytes([buf[1], buf[0]]),
+            panel_height: u16::from_be_bytes([buf[3], buf[2]]),
+            memory_address: u32::from_be_bytes([buf[7], buf[6], buf[5], buf[4]]),
+            firmware_version: Self::buf_to_str(&buf[8..24]),
+            lut_version: Self::buf_to_str(&buf[25..40]),
         })
     }
 
-    fn buf_to_string(&self, buf: &[u16]) -> String {
-        buf.iter()
-            .filter(|&&raw| raw != 0x0000)
-            .fold(String::new(), |mut res, &raw| {
-                if let Some(c) = char::from_u32((raw & 0xFF) as u32) {
-                    res.push(c);
-                }
-                if let Some(c) = char::from_u32((raw >> 8) as u32) {
-                    res.push(c);
-                }
-                res
-            })
+    fn buf_to_str(buffer: &[u8]) -> String {
+        String::from_iter(
+            buffer
+                .iter()
+                .filter(|&&raw| raw != 0x0000)
+                .map(|c| char::from(*c)),
+        )
     }
 
     fn get_vcom(&mut self) -> Result<u16, Error> {


### PR DESCRIPTION
With minimal API change to end users (who most likely don't use the memory_burst_read) get rid of the extra staging buffer in memory_burst_read and when initializing the device info.

In preparation of the removing alloc as dependency