### PR TITLE
Option not to set vcom on initialising

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,15 +216,8 @@ impl<IT8951Interface: interface::IT8951Interface, TOrigin: Origin>
     /// Initalize the driver and resets the display
     /// VCOM should be given on your display
     /// Since version 0.4.0, this function no longer resets the display
-    pub fn init(mut self, vcom: u16) -> Result<IT8951<IT8951Interface, TOrigin, Run>, Error> {
-        self.interface.reset()?;
-
-        let mut it8951 = self.into_state::<PowerDown>().sys_run()?;
-
-        let dev_info = it8951.get_system_info()?;
-
-        // Enable Pack Write
-        it8951.write_register(register::I80CPCR, 0x0001)?;
+    pub fn init(self, vcom: u16) -> Result<IT8951<IT8951Interface, TOrigin, Run>, Error> {
+        let mut it8951 = self.init_no_vcom()?;
 
         let current_vcom = it8951.get_vcom()?;
         if vcom != current_vcom {
@@ -233,6 +226,27 @@ impl<IT8951Interface: interface::IT8951Interface, TOrigin: Origin>
 
             it8951.set_vcom(vcom)?;
         }
+        Ok(it8951)
+    }
+
+    /// Initalize the driver and resets the display without setting VCOM
+    /// 
+    /// Use only in case where VCOM is set automatically by the IT8951.
+    /// Apparently this only tends to be done where the display and the IT8951
+    /// are shipped as one module and the VCOM calibration is stored at the factory
+    /// in OTP (one time programmable) memory.
+    /// 
+    /// Verify this by reading VCOM after calling init_no_vcom and see that it has
+    /// a sensible value (e.g. not 0x0000 or 0xFFFF)
+    pub fn init_no_vcom(mut self) -> Result<IT8951<IT8951Interface, TOrigin, Run>, Error> {
+        self.interface.reset()?;
+
+        let mut it8951 = self.into_state::<PowerDown>().sys_run()?;
+
+        let dev_info = it8951.get_system_info()?;
+
+        // Enable Pack Write
+        it8951.write_register(register::I80CPCR, 0x0001)?;
 
         #[cfg(feature = "defmt")]
         defmt::info!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,12 +230,12 @@ impl<IT8951Interface: interface::IT8951Interface, TOrigin: Origin>
     }
 
     /// Initalize the driver and resets the display without setting VCOM
-    /// 
+    ///
     /// Use only in case where VCOM is set automatically by the IT8951.
     /// Apparently this only tends to be done where the display and the IT8951
     /// are shipped as one module and the VCOM calibration is stored at the factory
     /// in OTP (one time programmable) memory.
-    /// 
+    ///
     /// Verify this by reading VCOM after calling init_no_vcom and see that it has
     /// a sensible value (e.g. not 0x0000 or 0xFFFF)
     pub fn init_no_vcom(mut self) -> Result<IT8951<IT8951Interface, TOrigin, Run>, Error> {
@@ -633,7 +633,10 @@ impl<IT8951Interface: interface::IT8951Interface, TOrigin: Origin>
         )
     }
 
-    fn get_vcom(&mut self) -> Result<u16, Error> {
+    /// Get the current VCOM setting for the panel
+    /// This should normally be set at initialising either by passing a value to init
+    /// or will be loaded automatically by the IT8951 from OTP (one time programmable memory)
+    pub fn get_vcom(&mut self) -> Result<u16, Error> {
         self.interface.write_command(command::USDEF_I80_CMD_VCOM)?;
         self.interface.write_data(0x0000)?;
         let vcom = self.interface.read_data()?;
@@ -644,7 +647,10 @@ impl<IT8951Interface: interface::IT8951Interface, TOrigin: Origin>
         Ok(vcom)
     }
 
-    fn set_vcom(&mut self, vcom: u16) -> Result<(), Error> {
+    /// Sets the VCOM for the panel
+    /// Set this with extreme caution. Using the wrong value can damage your panel. This will normally
+    /// be set during initialising.
+    pub fn set_vcom(&mut self, vcom: u16) -> Result<(), Error> {
         self.interface.write_command(command::USDEF_I80_CMD_VCOM)?;
         self.interface.write_data(0x0001)?;
         self.interface.write_data(vcom)?;


### PR DESCRIPTION
This is because some devices (e.g. M5 Paper) have a VCOM stored in OTP (one time programmable) memory that's automatically loaded. So this gives you the option for those devices of not setting it at startup.

Adding the ability to not set VCOM is a bit tricky as it could be misused to really mess up someone's panel but I suppose that's possible anyway currently by setting the incorrect VCOM setting on init.

Let me know if you want any changes